### PR TITLE
Add #447 Atlanta Motor Speedway - Oval

### DIFF
--- a/Tracks.txt
+++ b/Tracks.txt
@@ -334,4 +334,5 @@
 444 Fuji Speedway - Grand Prix
 445 Fuji Speedway - No chicanes
 446 Port Royal Speedway
+447 Atlanta Motor Speedway - Oval
 448 Indianapolis Motor Speedway - Road Course


### PR DESCRIPTION
Track for Oval S3W4 (a little bit useless now aswe are in S3W12 tomorrow but can be usefull for upcoming seasons :D