### PR TITLE
Remove space to display logo

### DIFF
--- a/Series.txt
+++ b/Series.txt
@@ -267,7 +267,7 @@
 	ID 457
 3868W2 Mission R Challenge - Fixed : Road
 	LICENSE D
-	ID 504	
+	ID 504
 0 MOAR Endurance Series
 3907W2 NASCAR Class A : Oval
 	LICENSE A


### PR DESCRIPTION
@bfiete when you add this serie yesterday and correct the spelling (LICENCE -> LICENSE), you add a space after the ID, that why the logo is not displayed for this serie.